### PR TITLE
ci: update publish step to use goreleaser

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,12 +44,12 @@ jobs:
         id: version_step
         run: |
           if [[ "${{ github.ref }}" == "refs/tags/v"* ]]; then
-            VERSION=${{ github.ref_name }}
+            VERSION="${{ github.ref_name }}"
           else
             VERSION="dev-${{ github.sha }}"
           fi
 
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,10 +8,6 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        goos: [linux, windows, darwin]
-        goarch: [amd64, arm64]
     steps:
       - uses: actions/checkout@v4
 
@@ -20,31 +16,11 @@ jobs:
         with:
           go-version-file: "./go.mod"
 
-      - name: Version Info
-        id: version_step
-        run: |
-          if [[ "${{ github.ref }}" == "refs/tags/v"* ]]; then
-            VERSION=${{ github.ref_name }}
-          else
-            VERSION="dev-${{ github.sha }}"
-          fi
-
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Build
-        env:
-          GOOS: ${{ matrix.goos }}
-          GOARCH: ${{ matrix.goarch }}
-        run: |
-          BINARY_NAME="ns_${{ matrix.goos }}-${{ matrix.goarch }}"
-          if [ "${{ matrix.goos }}" = "windows" ]; then
-            BINARY_NAME+=".exe"
-          fi
-          go build -ldflags="-w -s -X 'github.com/nowsecure/nowsecure-ci/cmd/ns/version.version=${{ steps.version_step.outputs.version }}'" -o $BINARY_NAME
-
-      - name: Upload Artifact
-        if: github.ref_type == 'tag'
-        uses: actions/upload-artifact@v4
+      - name: GoReleaser
+        uses: goreleaser/goreleaser-action@v6
         with:
-          name: ns_${{ matrix.goos }}-${{ matrix.goarch }}
-          path: ns_${{ matrix.goos }}-${{ matrix.goarch }}*
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bin
 release
 .DS_Store
 .direnv
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -23,7 +23,7 @@ builds:
 archives:
   - formats:
       - tgz
-    wrap_in_directory: true
+    wrap_in_directory: false
     # name template for the tgz files
     name_template: >-
       ns_{{ .Os }}-{{ .Arch }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,10 +3,6 @@
 
 version: 2
 
-before:
-  hooks:
-    - go mod tidy
-
 builds:
   - env:
       - CGO_ENABLED=0
@@ -31,6 +27,16 @@ archives:
     format_overrides:
       - goos: windows
         formats: [zip]
+
+nfpms:
+  - maintainer: NowSecure
+    description: A CLI interface for interacting with the NowSecure API
+    homepage: https://github.com/nowsecure/nowsecure-ci
+    license: MIT
+    formats:
+      - apk
+      - deb
+      - rpm
 
 changelog:
   sort: asc

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,10 +34,6 @@ archives:
 
 changelog:
   sort: asc
-  filters:
-    exclude:
-      - "^docs:"
-      - "^test:"
 
 release:
   footer: >-

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,47 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    ldflags:
+      - "-w -s -X 'github.com/nowsecure/nowsecure-ci/cmd/ns/version.version=${{ .Version }}'"
+    # name template for the binaries
+    binary: >-
+      ns_{{ .Os }}-{{ .Arch }}
+
+archives:
+  - formats:
+      - tgz
+    wrap_in_directory: true
+    # name template for the tgz files
+    name_template: >-
+      ns_{{ .Os }}-{{ .Arch }}
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+
+release:
+  footer: >-
+
+    ---
+
+    Released by [GoReleaser](https://github.com/goreleaser/goreleaser).

--- a/flake.nix
+++ b/flake.nix
@@ -3,41 +3,93 @@
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs";
 
-  outputs = { self, nixpkgs, ... }@inputs:
+  outputs =
+    { self, nixpkgs, ... }@inputs:
     let
       name = "ns-ci";
 
-      supportedSystems = [ "x86_64-linux" "aarch64-darwin" "aarch64-linux" ];
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-darwin"
+        "aarch64-linux"
+      ];
 
-      forEachSupportedSystem = f:
-        nixpkgs.lib.genAttrs supportedSystems
-        (system: f { pkgs = import nixpkgs { inherit system; }; });
+      forEachSupportedSystem =
+        f:
+        nixpkgs.lib.genAttrs supportedSystems (
+          system:
+          f {
+            pkgs = import nixpkgs { inherit system; };
+            system = system;
+          }
+        );
 
       vendorHash = nixpkgs.lib.fakeHash;
-    in {
-      devShells = forEachSupportedSystem ({ pkgs }: {
-        default = pkgs.mkShell {
-          packages = [
-            pkgs.go_1_24
-            pkgs.gopls
-            pkgs.golangci-lint
-            pkgs.gci
+    in
+    {
+      packages = forEachSupportedSystem (
+        { pkgs, system }:
+        {
+          default = pkgs.buildGo124Module {
+            inherit name vendorHash;
+            src = ./.;
+            doCheck = true;
+          };
+          format = pkgs.writeShellApplication {
+            name = "format";
+            runtimeInputs = [
+              pkgs.gci
+            ];
+            text = ''
+              gci write -s standard -s default -s localmodule ./
+            '';
+          };
+          checks = pkgs.writeShellApplication {
+            name = "checks";
+            runtimeInputs = [
+              pkgs.actionlint
+              pkgs.golangci-lint
+              pkgs.typos
+            ];
+            text = ''
+              set +e
+              echo "GolangCI Lint:"
+              golangci-lint run
+              echo "Action Lint:"
+              actionlint
+              echo "Typos:"
+              typos && echo "0 issues."
+            '';
+          };
+        }
+      );
 
-            pkgs.oapi-codegen
-            pkgs.cobra-cli
+      devShells = forEachSupportedSystem (
+        { pkgs, system }:
+        {
+          default = pkgs.mkShell {
+            packages = [
+              # Development dependancies
+              pkgs.cobra-cli
+              pkgs.go_1_24
+              pkgs.gopls
+              pkgs.oapi-codegen
 
-            pkgs.nixpkgs-fmt
-          ];
-        };
-      });
+              # Linting helpers
+              pkgs.actionlint
+              pkgs.gci
+              pkgs.golangci-lint
+              pkgs.typos
 
-      packages = forEachSupportedSystem ({ pkgs }: {
-        default = pkgs.buildGo124Module {
-          inherit name vendorHash;
-          src = ./.;
-          doCheck = true;
-        };
+              # Shell script helpers
+              self.packages.${system}.checks
+              self.packages.${system}.format
 
-      });
+              # Other
+              pkgs.nixpkgs-fmt
+            ];
+          };
+        }
+      );
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -69,7 +69,7 @@
         {
           default = pkgs.mkShell {
             packages = [
-              # Development dependancies
+              # Development dependencies
               pkgs.cobra-cli
               pkgs.go_1_24
               pkgs.gopls


### PR DESCRIPTION
- releases will now have tgz archives in the format: ns_darwin-arm64.tgz
- updates nix flake to include linting and formatting shell script helpers