### PR TITLE
chore(PI-5921): update default API endpoint to be api.nowsecure.com

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+NAME := nowsecure-ci
+BIN  := ./bin/ns
+EXE  := .
+
+default: ci
+
+ci: lint test dependencies-analyze
+
+build:
+	mkdir -p bin
+	CGO_ENABLED=0 go build -ldflags="-s -w" -o $(BIN) $(EXE)
+
+PACKAGES := $(shell go list ./...)
+
+test:
+	go run gotest.tools/gotestsum@latest --format testname $(PACKAGES)
+
+LINTER_ARGS := "--fix"
+
+lint:
+	@which golangci-lint > /dev/null || (echo "golangci-lint not found. Run 'nix develop' or install it manually." && exit 1)
+	golangci-lint run ${LINTER_ARGS} ./...
+
+dependencies-analyze:
+	which govulncheck || go install golang.org/x/vuln/cmd/govulncheck@latest
+	govulncheck ./...
+
+.PHONY: default ci build test lint dependencies-analyze

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The tool provides three methods to run security assessments:
 
 #### API Configuration
 
-- `--api-host` - REST API base URL (default: `https://lab-api.nowsecure.com`)
+- `--api-host` - REST API base URL (default: `https://api.nowsecure.com`)
   - Use this to point to a different NowSecure endpoint if you are accessing a single tenant instance
   
 - `--ui-host` - UI base URL (default: `https://app.nowsecure.com`)

--- a/cmd/ns/nowsecure.go
+++ b/cmd/ns/nowsecure.go
@@ -47,7 +47,7 @@ func RootCommand(ctx context.Context, v *viper.Viper, config *internal.BaseConfi
 	}
 
 	rootCmd.PersistentFlags().StringP("config", "c", "", "config file path")
-	rootCmd.PersistentFlags().String("api-host", "https://lab-api.nowsecure.com", "REST API base url")
+	rootCmd.PersistentFlags().String("api-host", "https://api.nowsecure.com", "REST API base url")
 	rootCmd.PersistentFlags().String("ui-host", "https://app.nowsecure.com", "UI base url")
 	rootCmd.PersistentFlags().String("token", "", "auth token for REST API")
 	rootCmd.PersistentFlags().String("group-ref", "", "group uuid with which to run assessments")

--- a/docs/cli/ns.md
+++ b/docs/cli/ns.md
@@ -5,7 +5,7 @@ NowSecure command line tool to interact with NowSecure Platform
 ### Options
 
 ```
-      --api-host string         REST API base url (default "https://lab-api.nowsecure.com")
+      --api-host string         REST API base url (default "https://api.nowsecure.com")
       --ci-environment string   appended to the user_agent header
   -c, --config string           config file path
       --group-ref string        group uuid with which to run assessments

--- a/docs/cli/ns_run.md
+++ b/docs/cli/ns_run.md
@@ -16,7 +16,7 @@ Run an assessment for a given application
 ### Options inherited from parent commands
 
 ```
-      --api-host string         REST API base url (default "https://lab-api.nowsecure.com")
+      --api-host string         REST API base url (default "https://api.nowsecure.com")
       --ci-environment string   appended to the user_agent header
   -c, --config string           config file path
       --group-ref string        group uuid with which to run assessments

--- a/docs/cli/ns_run_file.md
+++ b/docs/cli/ns_run_file.md
@@ -45,7 +45,7 @@ ns run file ./path/to/binary \
 
 ```
       --analysis-type string    One of: full, static, sbom (default "full")
-      --api-host string         REST API base url (default "https://lab-api.nowsecure.com")
+      --api-host string         REST API base url (default "https://api.nowsecure.com")
       --artifacts-dir string    directory in which to put artifacts (default "$PWD")
       --ci-environment string   appended to the user_agent header
   -c, --config string           config file path

--- a/docs/cli/ns_run_id.md
+++ b/docs/cli/ns_run_id.md
@@ -45,7 +45,7 @@ ns run id [app-id] \
 
 ```
       --analysis-type string    One of: full, static, sbom (default "full")
-      --api-host string         REST API base url (default "https://lab-api.nowsecure.com")
+      --api-host string         REST API base url (default "https://api.nowsecure.com")
       --artifacts-dir string    directory in which to put artifacts (default "$PWD")
       --ci-environment string   appended to the user_agent header
   -c, --config string           config file path

--- a/docs/cli/ns_run_package.md
+++ b/docs/cli/ns_run_package.md
@@ -51,7 +51,7 @@ ns run package [package-name] \
 
 ```
       --analysis-type string    One of: full, static, sbom (default "full")
-      --api-host string         REST API base url (default "https://lab-api.nowsecure.com")
+      --api-host string         REST API base url (default "https://api.nowsecure.com")
       --artifacts-dir string    directory in which to put artifacts (default "$PWD")
       --ci-environment string   appended to the user_agent header
   -c, --config string           config file path


### PR DESCRIPTION
In order to support the NS API consolidation:

- Updated the default endpoint to be api.nowsecure.com
- Updated docs to reference this change
- Added Makefile to follow NS defaults